### PR TITLE
use correct compare function for a std::string

### DIFF
--- a/7zpp/Enum.h
+++ b/7zpp/Enum.h
@@ -70,7 +70,7 @@ namespace intl
 			const StringValue* it = DerivedDef::Strings;
 			for (; it->string != NULL; ++it )
 			{
-				if ( string.Compare( it->string ) == 0 )
+				if ( string.compare( it->string ) == 0 )
 				{
 					return it->value;
 				}

--- a/Include/7zpp/Enum.h
+++ b/Include/7zpp/Enum.h
@@ -70,7 +70,7 @@ namespace intl
 			const StringValue* it = DerivedDef::Strings;
 			for (; it->string != NULL; ++it )
 			{
-				if ( string.Compare( it->string ) == 0 )
+				if ( string.compare( it->string ) == 0 )
 				{
 					return it->value;
 				}


### PR DESCRIPTION
Compare() is a function from 7z project, not std::string 